### PR TITLE
unique - handle token on mint event

### DIFF
--- a/src/mappings/uniques/mint.ts
+++ b/src/mappings/uniques/mint.ts
@@ -8,6 +8,7 @@ import { unwrap } from '../utils/extract'
 import { debug, pending, success } from '../utils/logger'
 import { Action, Context, createTokenId } from '../utils/types'
 import { versionOf , calculateCollectionOwnerCountAndDistribution } from '../utils/helper'
+import { handleTokenEntity } from '../shared/handleTokenEntity'
 import { getCreateTokenEvent } from './getters'
 
 const OPERATION = Action.MINT
@@ -60,6 +61,11 @@ export async function handleTokenCreate(context: Context): Promise<void> {
     final.name = metadata?.name
     final.image = metadata?.image
     final.media = metadata?.animationUrl
+  }
+
+  const token = await handleTokenEntity(context, collection, final)
+  if (token) {
+    final.token = token
   }
 
   success(OPERATION, `${final.id}`)


### PR DESCRIPTION
TokenEntity was broken on unique NFT's
because on unique pallet the token handling should happen on MINT event (unlike nft pallet)
This PR fixes that

@vikiival 