### PR TITLE
Fix-missing-collection

### DIFF
--- a/src/mappings/nfts/setMetadata.ts
+++ b/src/mappings/nfts/setMetadata.ts
@@ -39,6 +39,8 @@ export async function handleMetadataSet(context: Context): Promise<void> {
 
   if (final.metadata) {
     const metadata = await handleMetadata(final.metadata, context.store)
+    const previousNftMedia = final?.image || final?.media
+    const newNftMedia = metadata?.image || metadata?.animationUrl
     final.meta = metadata
     final.name = metadata?.name
     final.image = metadata?.image
@@ -51,7 +53,7 @@ export async function handleMetadataSet(context: Context): Promise<void> {
         warn(OPERATION, `collection ${event.collectionId} not found`)
         return
       }
-      if (final instanceof NFTEntity) {
+      if (final instanceof NFTEntity && newNftMedia !== previousNftMedia) {
         await setMetadataHandler(context, collection, final)
       }
     }

--- a/src/mappings/shared/token/setMetadata.ts
+++ b/src/mappings/shared/token/setMetadata.ts
@@ -11,20 +11,18 @@ export async function setMetadataHandler(context: Context, collection: CE, nft: 
   if (!nftMedia) {
     return
   }
+  const tokenAPI = new TokenAPI(context.store)
 
-  let nftWithToken
   try {
-    nftWithToken = await getWith(context.store, NE, nft.id, { token: true })
+    const nftWithToken = await getWith(context.store, NE, nft.id, { token: true })
+    if (nftWithToken.token) {
+      await tokenAPI.removeNftFromToken(nft, nftWithToken.token)
+    }
   } catch (error) {
     warn(OPERATION, `ERROR ${error}`)
     return
   }
 
-  const tokenAPI = new TokenAPI(context.store)
-
-  if (nftWithToken.token) {
-    await tokenAPI.removeNftFromToken(nft, nftWithToken.token)
-  }
   const existingToken = await getOptional<TE>(context.store, TE, generateTokenId(collection.id, nftMedia))
   return await (existingToken ? tokenAPI.addNftToToken(nft, existingToken) : tokenAPI.create(collection, nft))
 }

--- a/src/mappings/shared/token/setMetadata.ts
+++ b/src/mappings/shared/token/setMetadata.ts
@@ -12,12 +12,9 @@ export async function setMetadataHandler(context: Context, collection: CE, nft: 
     return
   }
 
-  let nftWithToken, existingToken
+  let nftWithToken
   try {
-    [nftWithToken, existingToken] = await Promise.all([
-      getWith(context.store, NE, nft.id, { token: true }),
-      getOptional<TE>(context.store, TE, generateTokenId(collection.id, nftMedia)),
-    ])
+    nftWithToken = await getWith(context.store, NE, nft.id, { token: true })
   } catch (error) {
     warn(OPERATION, `ERROR ${error}`)
     return
@@ -28,5 +25,6 @@ export async function setMetadataHandler(context: Context, collection: CE, nft: 
   if (nftWithToken.token) {
     await tokenAPI.removeNftFromToken(nft, nftWithToken.token)
   }
+  const existingToken = await getOptional<TE>(context.store, TE, generateTokenId(collection.id, nftMedia))
   return await (existingToken ? tokenAPI.addNftToToken(nft, existingToken) : tokenAPI.create(collection, nft))
 }

--- a/src/mappings/shared/token/setMetadata.ts
+++ b/src/mappings/shared/token/setMetadata.ts
@@ -15,7 +15,7 @@ export async function setMetadataHandler(context: Context, collection: CE, nft: 
 
   try {
     const nftWithToken = await getWith(context.store, NE, nft.id, { token: true })
-    if (nftWithToken.token) {
+    if (nftWithToken?.token) {
       await tokenAPI.removeNftFromToken(nft, nftWithToken.token)
     }
   } catch (error) {


### PR DESCRIPTION
- [x] Closes https://github.com/kodadot/nft-gallery/issues/7840


1.nft 20-2 had missing (null) collection data
2. Join (not left join) with collection_entity in the resolver  => entire result row dropped => missing nft in FE

Root Problem:
missing collection data

i found the bug was mis handling of the case where both these conditions happen:
a. Token has only 1 nft attached to it
b. a second set_metdata event is triggered on that nft WITH SAME image as before

combination of the conditions cuased the token to be deleted and the recreated with partial data

solution:
1. check if image is same as before, if so, no need to change anything about the tokens
2. decide if to create a new token for current nft or add it to a previously exisitng token only after potentialy deleting the token it was just detached from

## Bottom Line:

### Before:
![image](https://github.com/kodadot/stick/assets/22791238/ccc3a932-b11b-45bc-a16d-e1fbfe17f8ce)



### After

![image](https://github.com/kodadot/stick/assets/22791238/5f50b45e-e9f9-479c-bcc6-46903d9b58c3)



