### PR TITLE
fix/violate delete

### DIFF
--- a/src/mappings/shared/token/tokenAPI.ts
+++ b/src/mappings/shared/token/tokenAPI.ts
@@ -44,12 +44,11 @@ export class TokenAPI {
     debug(OPERATION, { removeNftFromToken: `Unlink NFT ${nft.id} from  TOKEN ${token.id}` })
 
     await emOf(this.store).update(NE, nft.id, { token: null })
-    const count = await emOf(this.store).countBy(NE, {
+    const updatedCount = await emOf(this.store).countBy(NE, {
       token: {
           id: token.id,
       },
   })
-    const updatedCount = count
     await emOf(this.store).update(TE, token.id, {
       supply: token.supply - 1,
       count: updatedCount,

--- a/src/mappings/shared/token/tokenAPI.ts
+++ b/src/mappings/shared/token/tokenAPI.ts
@@ -44,7 +44,12 @@ export class TokenAPI {
     debug(OPERATION, { removeNftFromToken: `Unlink NFT ${nft.id} from  TOKEN ${token.id}` })
 
     await emOf(this.store).update(NE, nft.id, { token: null })
-    const updatedCount = token.count - 1
+    const count = await emOf(this.store).countBy(NE, {
+      token: {
+          id: token.id,
+      },
+  })
+    const updatedCount = count
     await emOf(this.store).update(TE, token.id, {
       supply: token.supply - 1,
       count: updatedCount,


### PR DESCRIPTION
## Context

The point of the error #220 is that the count of tokenEntity is a bit skewed and if you are trying delete token entity that is still referenced it will fail

## Refs

- Close #220
- **:zap: use db count for removing**
