### PR TITLE
feat/base uri

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -3,6 +3,7 @@
 # https://github.com/paritytech/polkadot-sdk/blob/b8ad0d1f565659f004165c5244acba78828d0bf7/substrate/frame/nfts/src/lib.rs#L217
 type CollectionEntity @entity {
   attributes: [Attribute!]
+  baseUri: String
   blockNumber: BigInt @index
   burned: Boolean!
   createdAt: DateTime! @index

--- a/src/mappings/nfts/mint.ts
+++ b/src/mappings/nfts/mint.ts
@@ -7,7 +7,7 @@ import { handleMetadata } from '../shared/metadata'
 import { unwrap } from '../utils/extract'
 import { debug, pending, success } from '../utils/logger'
 import { Action, Context, createTokenId } from '../utils/types'
-import { calculateCollectionOwnerCountAndDistribution, versionOf } from '../utils/helper'
+import { calculateCollectionOwnerCountAndDistribution, tokenUri, versionOf } from '../utils/helper'
 import { mintHandler } from '../shared/token'
 import { getCreateTokenEvent } from './getters'
 
@@ -42,7 +42,7 @@ export async function handleTokenCreate(context: Context): Promise<void> {
   final.blockNumber = BigInt(event.blockNumber)
   final.collection = collection
   final.sn = BigInt(event.sn)
-  final.metadata = event.metadata || collection.metadata
+  final.metadata = event.metadata || tokenUri(collection.baseUri, event.sn) || collection.metadata
   final.price = BigInt(0)
   final.burned = false
   final.createdAt = event.timestamp

--- a/src/mappings/nfts/setAttribute.ts
+++ b/src/mappings/nfts/setAttribute.ts
@@ -28,6 +28,11 @@ export async function handleAttributeSet(context: Context): Promise<void> {
     final.royalty = final.royalty || Number.parseFloat(value || '0')
   }
 
+  if ('baseUri' in final && event.trait === 'baseUri') {
+    const value = unHex(event.value)
+    final.baseUri = final.baseUri || value
+  }
+
   if ('recipient' in final && event.trait === 'recipient') {
     try {
       final.recipient = final.recipient || addressOf(event.value as string)

--- a/src/mappings/nfts/setAttribute.ts
+++ b/src/mappings/nfts/setAttribute.ts
@@ -25,15 +25,15 @@ export async function handleAttributeSet(context: Context): Promise<void> {
 
   if ('royalty' in final && event.trait === 'royalty') {
     const value = unHex(event.value)
-    final.royalty = final.royalty ?? Number.parseFloat(value || '0')
+    final.royalty = final.royalty || Number.parseFloat(value || '0')
   }
 
   if ('recipient' in final && event.trait === 'recipient') {
     try {
-      final.recipient = final.recipient ?? addressOf(event.value as string)
+      final.recipient = final.recipient || addressOf(event.value as string)
     } catch (error) {
       console.log(error)
-      final.recipient = final.recipient ?? (event.value as string)
+      final.recipient = '' // final.recipient ?? (event.value as string)
     }
   }
 

--- a/src/mappings/utils/helper.ts
+++ b/src/mappings/utils/helper.ts
@@ -1,5 +1,5 @@
 import { emOf } from '@kodadot1/metasquid/entity'
-import { ArchiveCallWithOptionalValue, Store } from '@kodadot1/metasquid/types'
+import { ArchiveCallWithOptionalValue, Optional, Store } from '@kodadot1/metasquid/types'
 import * as ss58 from '@subsquid/ss58'
 import { decodeHex } from '@subsquid/substrate-processor'
 import { CHAIN } from '../../environment'
@@ -10,8 +10,6 @@ const codec = CHAIN
 
 export const UNIQUE_PREFIX = 'u' as const
 export const EMPTY = '' as const
-
-type Optional<T> = T | undefined
 
 /**
  * Check if an object is empty

--- a/src/mappings/utils/helper.ts
+++ b/src/mappings/utils/helper.ts
@@ -62,6 +62,20 @@ export function unHex<T>(value: T): T | string {
 }
 
 /**
+ * create a token uri from the base uri and the token id
+ * @param baseUri - base uri from the collection
+ * @param tokenId - the token id
+**/
+export function tokenUri(baseUri: Optional<string>, tokenId: Optional<string>): string {
+  if (!baseUri || !tokenId) {
+    return ''
+  }
+  
+  const uri = baseUri.endsWith('/') ? baseUri : `${baseUri}/`
+  return `${uri}${tokenId}`
+}
+
+/**
  * @deprecated Use the unjs/ufo package
  **/
 export function camelCase(str: string): string {

--- a/src/model/generated/assetEntity.model.ts
+++ b/src/model/generated/assetEntity.model.ts
@@ -1,4 +1,4 @@
-import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_} from "typeorm"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_, IntColumn as IntColumn_} from "@subsquid/typeorm-store"
 
 @Entity_()
 export class AssetEntity {
@@ -9,12 +9,12 @@ export class AssetEntity {
     @PrimaryColumn_()
     id!: string
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     name!: string | undefined | null
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     symbol!: string | undefined | null
 
-    @Column_("int4", {nullable: true})
+    @IntColumn_({nullable: true})
     decimals!: number | undefined | null
 }

--- a/src/model/generated/cacheStatus.model.ts
+++ b/src/model/generated/cacheStatus.model.ts
@@ -1,4 +1,4 @@
-import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_} from "typeorm"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, DateTimeColumn as DateTimeColumn_} from "@subsquid/typeorm-store"
 
 @Entity_()
 export class CacheStatus {
@@ -9,6 +9,6 @@ export class CacheStatus {
     @PrimaryColumn_()
     id!: string
 
-    @Column_("timestamp with time zone", {nullable: false})
+    @DateTimeColumn_({nullable: false})
     lastBlockTimestamp!: Date
 }

--- a/src/model/generated/collectionEntity.model.ts
+++ b/src/model/generated/collectionEntity.model.ts
@@ -1,4 +1,4 @@
-import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, Index as Index_, OneToMany as OneToMany_, ManyToOne as ManyToOne_} from "typeorm"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_, BigIntColumn as BigIntColumn_, Index as Index_, BooleanColumn as BooleanColumn_, DateTimeColumn as DateTimeColumn_, IntColumn as IntColumn_, OneToMany as OneToMany_, ManyToOne as ManyToOne_, FloatColumn as FloatColumn_} from "@subsquid/typeorm-store"
 import * as marshal from "./marshal"
 import {Attribute} from "./_attribute"
 import {CollectionEvent} from "./collectionEvent.model"
@@ -16,93 +16,96 @@ export class CollectionEntity {
     @Column_("jsonb", {transformer: {to: obj => obj == null ? undefined : obj.map((val: any) => val.toJSON()), from: obj => obj == null ? undefined : marshal.fromList(obj, val => new Attribute(undefined, marshal.nonNull(val)))}, nullable: true})
     attributes!: (Attribute)[] | undefined | null
 
+    @StringColumn_({nullable: true})
+    baseUri!: string | undefined | null
+
     @Index_()
-    @Column_("numeric", {transformer: marshal.bigintTransformer, nullable: true})
+    @BigIntColumn_({nullable: true})
     blockNumber!: bigint | undefined | null
 
-    @Column_("bool", {nullable: false})
+    @BooleanColumn_({nullable: false})
     burned!: boolean
 
     @Index_()
-    @Column_("timestamp with time zone", {nullable: false})
+    @DateTimeColumn_({nullable: false})
     createdAt!: Date
 
-    @Column_("text", {nullable: false})
+    @StringColumn_({nullable: false})
     currentOwner!: string
 
-    @Column_("int4", {nullable: false})
+    @IntColumn_({nullable: false})
     distribution!: number
 
     @OneToMany_(() => CollectionEvent, e => e.collection)
     events!: CollectionEvent[]
 
     @Index_()
-    @Column_("numeric", {transformer: marshal.bigintTransformer, nullable: false})
+    @BigIntColumn_({nullable: false})
     floor!: bigint
 
     @Index_({unique: true})
-    @Column_("text", {nullable: false})
+    @StringColumn_({nullable: false})
     hash!: string
 
     @Index_()
-    @Column_("numeric", {transformer: marshal.bigintTransformer, nullable: false})
+    @BigIntColumn_({nullable: false})
     highestSale!: bigint
 
     @PrimaryColumn_()
     id!: string
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     image!: string | undefined | null
 
-    @Column_("text", {nullable: false})
+    @StringColumn_({nullable: false})
     issuer!: string
 
-    @Column_("int4", {nullable: true})
+    @IntColumn_({nullable: true})
     max!: number | undefined | null
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     media!: string | undefined | null
 
     @Index_()
     @ManyToOne_(() => MetadataEntity, {nullable: true})
     meta!: MetadataEntity | undefined | null
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     metadata!: string | undefined | null
 
     @Index_()
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     name!: string | undefined | null
 
     @Index_()
-    @Column_("int4", {nullable: false})
+    @IntColumn_({nullable: false})
     nftCount!: number
 
     @OneToMany_(() => NFTEntity, e => e.collection)
     nfts!: NFTEntity[]
 
-    @Column_("int4", {nullable: false})
+    @IntColumn_({nullable: false})
     ownerCount!: number
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     recipient!: string | undefined | null
 
-    @Column_("numeric", {transformer: marshal.floatTransformer, nullable: true})
+    @FloatColumn_({nullable: true})
     royalty!: number | undefined | null
 
     @Index_()
-    @Column_("int4", {nullable: false})
+    @IntColumn_({nullable: false})
     supply!: number
 
     @Index_()
-    @Column_("timestamp with time zone", {nullable: false})
+    @DateTimeColumn_({nullable: false})
     updatedAt!: Date
 
-    @Column_("int4", {nullable: false})
+    @IntColumn_({nullable: false})
     version!: number
 
     @Index_()
-    @Column_("numeric", {transformer: marshal.bigintTransformer, nullable: false})
+    @BigIntColumn_({nullable: false})
     volume!: bigint
 
     @Column_("varchar", {length: 8, nullable: true})

--- a/src/model/generated/collectionEvent.model.ts
+++ b/src/model/generated/collectionEvent.model.ts
@@ -1,5 +1,4 @@
-import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, ManyToOne as ManyToOne_, Index as Index_} from "typeorm"
-import * as marshal from "./marshal"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, BigIntColumn as BigIntColumn_, DateTimeColumn as DateTimeColumn_, StringColumn as StringColumn_, ManyToOne as ManyToOne_, Index as Index_} from "@subsquid/typeorm-store"
 import {Interaction} from "./_interaction"
 import {CollectionEntity} from "./collectionEntity.model"
 
@@ -12,22 +11,22 @@ export class CollectionEvent {
     @PrimaryColumn_()
     id!: string
 
-    @Column_("numeric", {transformer: marshal.bigintTransformer, nullable: true})
+    @BigIntColumn_({nullable: true})
     blockNumber!: bigint | undefined | null
 
-    @Column_("timestamp with time zone", {nullable: false})
+    @DateTimeColumn_({nullable: false})
     timestamp!: Date
 
-    @Column_("text", {nullable: false})
+    @StringColumn_({nullable: false})
     caller!: string
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     currentOwner!: string | undefined | null
 
     @Column_("varchar", {length: 12, nullable: false})
     interaction!: Interaction
 
-    @Column_("text", {nullable: false})
+    @StringColumn_({nullable: false})
     meta!: string
 
     @Index_()

--- a/src/model/generated/event.model.ts
+++ b/src/model/generated/event.model.ts
@@ -1,5 +1,4 @@
-import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, ManyToOne as ManyToOne_, Index as Index_} from "typeorm"
-import * as marshal from "./marshal"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, BigIntColumn as BigIntColumn_, DateTimeColumn as DateTimeColumn_, StringColumn as StringColumn_, ManyToOne as ManyToOne_, Index as Index_} from "@subsquid/typeorm-store"
 import {Interaction} from "./_interaction"
 import {NFTEntity} from "./nftEntity.model"
 
@@ -12,22 +11,22 @@ export class Event {
     @PrimaryColumn_()
     id!: string
 
-    @Column_("numeric", {transformer: marshal.bigintTransformer, nullable: true})
+    @BigIntColumn_({nullable: true})
     blockNumber!: bigint | undefined | null
 
-    @Column_("timestamp with time zone", {nullable: false})
+    @DateTimeColumn_({nullable: false})
     timestamp!: Date
 
-    @Column_("text", {nullable: false})
+    @StringColumn_({nullable: false})
     caller!: string
 
-    @Column_("text", {nullable: false})
+    @StringColumn_({nullable: false})
     currentOwner!: string
 
     @Column_("varchar", {length: 12, nullable: false})
     interaction!: Interaction
 
-    @Column_("text", {nullable: false})
+    @StringColumn_({nullable: false})
     meta!: string
 
     @Index_()

--- a/src/model/generated/marshal.ts
+++ b/src/model/generated/marshal.ts
@@ -127,36 +127,6 @@ export function nonNull<T>(val: T | undefined | null): T {
 }
 
 
-export const bigintTransformer = {
-    to(x?: bigint) {
-        return x?.toString()
-    },
-    from(s?: string): bigint | undefined {
-        return s == null ? undefined : BigInt(s)
-    }
-}
-
-
-export const floatTransformer = {
-    to(x?: number) {
-        return x?.toString()
-    },
-    from(s?: string): number | undefined {
-        return s == null ? undefined : Number(s)
-    }
-}
-
-
-export const bigdecimalTransformer = {
-    to(x?: any) {
-        return x?.toString()
-    },
-    from(s?: any): any | undefined {
-        return s == null ? undefined : decimal.BigDecimal(s)
-    }
-}
-
-
 export function enumFromJson<E extends object>(json: unknown, enumObject: E): E[keyof E] {
     assert(typeof json == 'string', 'invalid enum value')
     let val = (enumObject as any)[json]

--- a/src/model/generated/metadataEntity.model.ts
+++ b/src/model/generated/metadataEntity.model.ts
@@ -1,4 +1,4 @@
-import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_} from "typeorm"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_} from "@subsquid/typeorm-store"
 import * as marshal from "./marshal"
 import {Attribute} from "./_attribute"
 
@@ -11,24 +11,24 @@ export class MetadataEntity {
     @PrimaryColumn_()
     id!: string
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     name!: string | undefined | null
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     description!: string | undefined | null
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     image!: string | undefined | null
 
     @Column_("jsonb", {transformer: {to: obj => obj == null ? undefined : obj.map((val: any) => val.toJSON()), from: obj => obj == null ? undefined : marshal.fromList(obj, val => new Attribute(undefined, marshal.nonNull(val)))}, nullable: true})
     attributes!: (Attribute)[] | undefined | null
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     animationUrl!: string | undefined | null
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     type!: string | undefined | null
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     banner!: string | undefined | null
 }

--- a/src/model/generated/nftEntity.model.ts
+++ b/src/model/generated/nftEntity.model.ts
@@ -1,4 +1,4 @@
-import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, Index as Index_, ManyToOne as ManyToOne_, OneToMany as OneToMany_} from "typeorm"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, BigIntColumn as BigIntColumn_, Index as Index_, BooleanColumn as BooleanColumn_, ManyToOne as ManyToOne_, DateTimeColumn as DateTimeColumn_, StringColumn as StringColumn_, OneToMany as OneToMany_, FloatColumn as FloatColumn_, IntColumn as IntColumn_} from "@subsquid/typeorm-store"
 import * as marshal from "./marshal"
 import {Attribute} from "./_attribute"
 import {CollectionEntity} from "./collectionEntity.model"
@@ -16,10 +16,10 @@ export class NFTEntity {
     attributes!: (Attribute)[] | undefined | null
 
     @Index_()
-    @Column_("numeric", {transformer: marshal.bigintTransformer, nullable: true})
+    @BigIntColumn_({nullable: true})
     blockNumber!: bigint | undefined | null
 
-    @Column_("bool", {nullable: false})
+    @BooleanColumn_({nullable: false})
     burned!: boolean
 
     @Index_()
@@ -27,65 +27,65 @@ export class NFTEntity {
     collection!: CollectionEntity
 
     @Index_()
-    @Column_("timestamp with time zone", {nullable: false})
+    @DateTimeColumn_({nullable: false})
     createdAt!: Date
 
     @Index_()
-    @Column_("text", {nullable: false})
+    @StringColumn_({nullable: false})
     currentOwner!: string
 
     @OneToMany_(() => Event, e => e.nft)
     events!: Event[]
 
     @Index_()
-    @Column_("text", {nullable: false})
+    @StringColumn_({nullable: false})
     hash!: string
 
     @PrimaryColumn_()
     id!: string
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     image!: string | undefined | null
 
-    @Column_("text", {nullable: false})
+    @StringColumn_({nullable: false})
     issuer!: string
 
-    @Column_("bool", {nullable: false})
+    @BooleanColumn_({nullable: false})
     lewd!: boolean
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     media!: string | undefined | null
 
     @Index_()
     @ManyToOne_(() => MetadataEntity, {nullable: true})
     meta!: MetadataEntity | undefined | null
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     metadata!: string | undefined | null
 
     @Index_()
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     name!: string | undefined | null
 
     @Index_()
-    @Column_("numeric", {transformer: marshal.bigintTransformer, nullable: true})
+    @BigIntColumn_({nullable: true})
     price!: bigint | undefined | null
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     recipient!: string | undefined | null
 
-    @Column_("numeric", {transformer: marshal.floatTransformer, nullable: true})
+    @FloatColumn_({nullable: true})
     royalty!: number | undefined | null
 
     @Index_()
-    @Column_("numeric", {transformer: marshal.bigintTransformer, nullable: false})
+    @BigIntColumn_({nullable: false})
     sn!: bigint
 
     @Index_()
-    @Column_("timestamp with time zone", {nullable: false})
+    @DateTimeColumn_({nullable: false})
     updatedAt!: Date
 
-    @Column_("int4", {nullable: false})
+    @IntColumn_({nullable: false})
     version!: number
 
     @Index_()

--- a/src/model/generated/tokenEntity.model.ts
+++ b/src/model/generated/tokenEntity.model.ts
@@ -1,5 +1,4 @@
-import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, ManyToOne as ManyToOne_, Index as Index_, OneToMany as OneToMany_} from "typeorm"
-import * as marshal from "./marshal"
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, BigIntColumn as BigIntColumn_, ManyToOne as ManyToOne_, Index as Index_, OneToMany as OneToMany_, StringColumn as StringColumn_, DateTimeColumn as DateTimeColumn_, IntColumn as IntColumn_, BooleanColumn as BooleanColumn_} from "@subsquid/typeorm-store"
 import {CollectionEntity} from "./collectionEntity.model"
 import {NFTEntity} from "./nftEntity.model"
 import {MetadataEntity} from "./metadataEntity.model"
@@ -13,7 +12,7 @@ export class TokenEntity {
     @PrimaryColumn_()
     id!: string
 
-    @Column_("numeric", {transformer: marshal.bigintTransformer, nullable: true})
+    @BigIntColumn_({nullable: true})
     blockNumber!: bigint | undefined | null
 
     @Index_()
@@ -24,38 +23,38 @@ export class TokenEntity {
     nfts!: NFTEntity[]
 
     @Index_()
-    @Column_("text", {nullable: false})
+    @StringColumn_({nullable: false})
     hash!: string
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     image!: string | undefined | null
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     media!: string | undefined | null
 
     @Index_()
     @ManyToOne_(() => MetadataEntity, {nullable: true})
     meta!: MetadataEntity | undefined | null
 
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     metadata!: string | undefined | null
 
     @Index_()
-    @Column_("text", {nullable: true})
+    @StringColumn_({nullable: true})
     name!: string | undefined | null
 
-    @Column_("timestamp with time zone", {nullable: false})
+    @DateTimeColumn_({nullable: false})
     updatedAt!: Date
 
-    @Column_("timestamp with time zone", {nullable: false})
+    @DateTimeColumn_({nullable: false})
     createdAt!: Date
 
-    @Column_("int4", {nullable: false})
+    @IntColumn_({nullable: false})
     supply!: number
 
-    @Column_("int4", {nullable: false})
+    @IntColumn_({nullable: false})
     count!: number
 
-    @Column_("bool", {nullable: false})
+    @BooleanColumn_({nullable: false})
     deleted!: boolean
 }


### PR DESCRIPTION
### Context


I have ported the implementation of basick metadata resolving to stick

### How it works

basically: if collection has `baseUri` set
it will resolve first `nft.metadata` as `baseUri` + `sn`

Therefore is not dependable on the **external_services**


### Commits

- **Ability to rewrite incorrect values**
- **:zap: tokenUri to calculate next uri**
- **:squid: codegen**
- **:alien: baseUri**
- **:zap: apply base uri to collection**
- **:label: metaquid is you good friend**
- **:zap: useBaseUri**
