### PR TITLE
🐛 swaps without `surcharge`

### DIFF
--- a/src/mappings/nfts/createSwap.ts
+++ b/src/mappings/nfts/createSwap.ts
@@ -45,8 +45,8 @@ export async function handleCreateSwap(context: Context): Promise<void> {
   final.desired = desired
   final.expiration = deadline
   final.price = event.price
-  if ('surcharge' in final) {
-    final.surcharge = event.surcharge
+  if (!offer) {
+    (final as Swap).surcharge = event.surcharge
   }
   final.status = final.blockNumber >= deadline ? TradeStatus.EXPIRED : TradeStatus.ACTIVE
   final.updatedAt = event.timestamp


### PR DESCRIPTION
if the swap is new final has only the `id`

![CleanShot 2024-11-29 at 08 44 10@2x](https://github.com/user-attachments/assets/e1ff4168-01fa-41ef-a2c3-ec7df10bb061)
