### PR TITLE
🐛 swaps with old swap data

### DIFF
--- a/src/mappings/nfts/createSwap.ts
+++ b/src/mappings/nfts/createSwap.ts
@@ -35,7 +35,7 @@ export async function handleCreateSwap(context: Context): Promise<void> {
   // the nft that is being swapped
   const nft = await get(context.store, NE, id)
   const considered = await get(context.store, CE, event.consideration.collectionId)
-  const desired = isNFT(event.consideration) ? await get(context.store, NE, tokenIdOf(event.consideration as any)) : undefined
+  const desired = isNFT(event.consideration) ? await get(context.store, NE, tokenIdOf(event.consideration as any)) : null
 
   final.blockNumber = BigInt(event.blockNumber)
   final.createdAt = event.timestamp
@@ -44,9 +44,9 @@ export async function handleCreateSwap(context: Context): Promise<void> {
   final.considered = considered
   final.desired = desired
   final.expiration = deadline
-  final.price = event.price
+  final.price = event.price || null
   if (!offer) {
-    (final as Swap).surcharge = event.surcharge
+    (final as Swap).surcharge = event.surcharge || null
   }
   final.status = final.blockNumber >= deadline ? TradeStatus.EXPIRED : TradeStatus.ACTIVE
   final.updatedAt = event.timestamp


### PR DESCRIPTION
### Context 

 when overriding a swap, some fields like price, surcharge, and desired will carry over old data to the new swap.

### How to reproduce

1. create swap
    - offeredCollection: 138
    - offeredItem: 2
    - desiredCollection: 256
    - desiredItem: 4233829487
     - price: 1DOT
     - surcharge: send

<img src=https://github.com/user-attachments/assets/9e10a52c-7513-485c-8e0e-6c58b4a52cc5 width=400 />





2. create a second swap with same offered item and **do not add price or desired (swap entire collection)**
    - offeredCollection: 138
    - offeredItem: 2
    - desiredCollection: 256

<img src=https://github.com/user-attachments/assets/b1b447a4-4025-4782-980b-d873b79ad26f width=400 />


price , surcharge, and desired is carrying over from the old swap