### PR TITLE
:tada: Add AssetHub Paseo

### DIFF
--- a/snack.yaml
+++ b/snack.yaml
@@ -1,0 +1,41 @@
+manifestVersion: subsquid.io/v0.1
+name: snack
+version: 1
+description: 'SubSquid indexer for Uniques and Assets on AssetHub Paseo'
+build: 
+deploy:
+  addons:
+    postgres:
+      config:
+        statement_timeout: 30000
+        log_min_duration_statement: 5000
+  processor:
+    cmd:
+      - node
+      - lib/processor
+    env:
+      CHAIN: paseo
+      OFFER: ''
+      UNIQUES_ENABLED: false
+      STARTING_BLOCK:	142362
+      UNIQUE_STARTING_BLOCK: 360613
+  api:
+    cmd:
+      - npx
+      - squid-graphql-server
+      - '--subscriptions'
+      - '--dumb-cache'
+      - in-memory
+      - '--dumb-cache-ttl'
+      - '1000'
+      - '--dumb-cache-size'
+      - '100'
+      - '--dumb-cache-max-age'
+      - '1000'
+
+scale:
+  dedicated: false
+  addons:
+    postgres:
+      storage: 2G
+      profile: medium

--- a/speck.yaml
+++ b/speck.yaml
@@ -17,6 +17,8 @@ deploy:
       CHAIN: polkadot
       OFFER: 174
       UNIQUES_ENABLED: true
+      STARTING_BLOCK: 4232387
+      UNIQUE_STARTING_BLOCK: 1212469
   api:
     cmd:
       - npx

--- a/squid.yaml
+++ b/squid.yaml
@@ -17,6 +17,8 @@ deploy:
       CHAIN: kusama
       OFFER: 464
       UNIQUES_ENABLED: true
+      STARTING_BLOCK: 4556552
+      UNIQUE_STARTING_BLOCK: 618838
   api:
     cmd:
       - npx

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,4 +1,4 @@
-export type Chain = 'kusama' | 'rococo' | 'polkadot'
+export type Chain = 'kusama' | 'paseo' | 'polkadot'
 
 export const CHAIN: Chain = process.env.CHAIN as Chain || 'kusama'
 export const COLLECTION_OFFER: string = process.env.OFFER || ''
@@ -12,7 +12,7 @@ export const STARTING_BLOCK = UNIQUES_ENABLED ? UNIQUE_STARTING_BLOCK : NFT_STAR
 const ARCHIVE_URL = `https://v2.archive.subsquid.io/network/asset-hub-${CHAIN}`
 const NODE_URL = `wss://${CHAIN}-asset-hub-rpc.polkadot.io`
 
-export const isProd = CHAIN !== 'rococo'
+export const isProd = CHAIN !== 'paseo'
 
 console.table({
   CHAIN, ARCHIVE_URL, NODE_URL, STARTING_BLOCK,


### PR DESCRIPTION
- **fix(environment): update Chain type to include 'paseo' and adjust production check**
- **fix(env): add starting block and unique starting block for paseo and statemine**
- **feat(snack): add initial configuration for SubSquid indexer on AssetHub Paseo**
