### PR TITLE
feat(Rarity System): add automatic NFT Rarity rank and scoring based on traits distribution

### DIFF
--- a/db/migrations/1760160000000-Data.js
+++ b/db/migrations/1760160000000-Data.js
@@ -1,0 +1,25 @@
+module.exports = class Data1760160000000 {
+    name = 'Data1760160000000'
+
+    async up(db) {
+        await db.query(`ALTER TABLE "nft_entity" ADD "rarity_score" numeric`)
+        await db.query(`ALTER TABLE "nft_entity" ADD "rarity_rank" integer`)
+        await db.query(`ALTER TABLE "nft_entity" ADD "rarity_percentile" numeric`)
+        await db.query(`ALTER TABLE "nft_entity" ADD "rarity_tier" text`)
+
+        await db.query(`CREATE INDEX "IDX_nft_entity_collection_rarity_rank" ON "nft_entity" ("collection_id", "rarity_rank") `)
+        await db.query(`CREATE INDEX "IDX_nft_entity_collection_rarity_tier" ON "nft_entity" ("collection_id", "rarity_tier") `)
+        await db.query(`CREATE INDEX "IDX_nft_entity_collection_rarity_percentile" ON "nft_entity" ("collection_id", "rarity_percentile") `)
+    }
+
+    async down(db) {
+        await db.query(`DROP INDEX "public"."IDX_nft_entity_collection_rarity_percentile"`)
+        await db.query(`DROP INDEX "public"."IDX_nft_entity_collection_rarity_tier"`)
+        await db.query(`DROP INDEX "public"."IDX_nft_entity_collection_rarity_rank"`)
+
+        await db.query(`ALTER TABLE "nft_entity" DROP COLUMN "rarity_tier"`)
+        await db.query(`ALTER TABLE "nft_entity" DROP COLUMN "rarity_percentile"`)
+        await db.query(`ALTER TABLE "nft_entity" DROP COLUMN "rarity_rank"`)
+        await db.query(`ALTER TABLE "nft_entity" DROP COLUMN "rarity_score"`)
+    }
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -80,6 +80,10 @@ type NFTEntity @entity {
   recipient: String
   royalty: Float
   sn: BigInt! @index
+  rarityScore: Float @index
+  rarityRank: Int @index
+  rarityPercentile: Float @index
+  rarityTier: String @index
   # swap: Swap @derivedFrom(field: "nft")
   updatedAt: DateTime! @index
   version: Int!

--- a/src/mappings/index.ts
+++ b/src/mappings/index.ts
@@ -10,6 +10,7 @@ import * as u from './uniques'
 import { BatchContext, Block, Context, SelectedEvent } from './utils/types'
 import { ParachainSystemCall } from '../processable'
 import { updateSwapsCache } from './utils/cache'
+import { flushDirtyCollectionRarity } from './utils/rarity'
 
 type HandlerFunction = <T extends SelectedEvent>(item: T, ctx: Context) => Promise<void>
 
@@ -247,6 +248,8 @@ export async function mainFrame(ctx: BatchContext<Store>): Promise<void> {
       })
       // const item = event
     }
+
+    await flushDirtyCollectionRarity(ctx.store)
   }
 
   if (ctx.isHead) {

--- a/src/mappings/nfts/burn.ts
+++ b/src/mappings/nfts/burn.ts
@@ -7,6 +7,7 @@ import { createEvent } from '../shared/event'
 import { calculateCollectionFloor, calculateCollectionOwnerCountAndDistribution } from '../utils/helper'
 import { burnHandler } from '../shared/token'
 import { getBurnTokenEvent } from './getters'
+import { markCollectionRarityDirty } from '../utils/rarity'
 
 const OPERATION = Action.BURN
 
@@ -45,6 +46,7 @@ export async function handleTokenBurn(context: Context): Promise<void> {
   success(OPERATION, `${id} by ${event.caller}`)
   await context.store.save(entity)
   await context.store.save(entity.collection)
+  markCollectionRarityDirty(entity.collection.id)
   const meta = entity.metadata ?? ''
   await createEvent(entity, OPERATION, event, meta, context.store)
 

--- a/src/mappings/nfts/mint.ts
+++ b/src/mappings/nfts/mint.ts
@@ -10,6 +10,7 @@ import { Action, Context, createTokenId } from '../utils/types'
 import { calculateCollectionOwnerCountAndDistribution, tokenUri, versionOf } from '../utils/helper'
 import { mintHandler } from '../shared/token'
 import { getCreateTokenEvent } from './getters'
+import { markCollectionRarityDirty } from '../utils/rarity'
 
 const OPERATION = Action.MINT
 
@@ -83,6 +84,7 @@ export async function handleTokenCreate(context: Context): Promise<void> {
   success(OPERATION, `${final.id}`)
   await context.store.save(final)
   await context.store.save(collection)
+  markCollectionRarityDirty(collection.id)
   
   const destinationAddress = final.issuer !== final.currentOwner ? final.currentOwner : ''
   

--- a/src/mappings/nfts/setAttribute.ts
+++ b/src/mappings/nfts/setAttribute.ts
@@ -5,6 +5,7 @@ import { Context, isNFT } from '../utils/types'
 import { addressOf, isAddress, unHex } from '../utils/helper'
 import { getAttributeEvent } from './getters'
 import { attributeFrom, tokenIdOf } from './types'
+import { markCollectionRarityDirty } from '../utils/rarity'
 
 /**
  * Handle the attribute set event (Nfts.AttributeSet, Nfts.AttributeCleared)
@@ -58,4 +59,5 @@ export async function handleAttributeSet(context: Context): Promise<void> {
   }
 
   await context.store.save(final)
+  markCollectionRarityDirty(event.collectionId)
 }

--- a/src/mappings/nfts/setMetadata.ts
+++ b/src/mappings/nfts/setMetadata.ts
@@ -9,6 +9,7 @@ import { updateItemMetadataByCollection } from '../utils/cache'
 import { setMetadataHandler } from '../shared/token'
 import { tokenIdOf } from './types'
 import { getMetadataEvent } from './getters'
+import { markCollectionRarityDirty } from '../utils/rarity'
 
 const OPERATION = 'METADATA' as any
 
@@ -20,6 +21,7 @@ const OPERATION = 'METADATA' as any
 export async function handleMetadataSet(context: Context): Promise<void> {
   const event = unwrap(context, getMetadataEvent)
   debug(OPERATION, event)
+  markCollectionRarityDirty(event.collectionId)
 
   if (!event.metadata) {
     return

--- a/src/mappings/uniques/burn.ts
+++ b/src/mappings/uniques/burn.ts
@@ -7,6 +7,7 @@ import { createEvent } from '../shared/event'
 import { calculateCollectionFloor, calculateCollectionOwnerCountAndDistribution } from '../utils/helper'
 import { burnHandler } from '../shared/token'
 import { getBurnTokenEvent } from './getters'
+import { markCollectionRarityDirty } from '../utils/rarity'
 
 const OPERATION = Action.BURN
 
@@ -45,6 +46,7 @@ export async function handleTokenBurn(context: Context): Promise<void> {
   success(OPERATION, `${id} by ${event.caller}`)
   await context.store.save(entity)
   await context.store.save(entity.collection)
+  markCollectionRarityDirty(entity.collection.id)
   const meta = entity.metadata ?? ''
   await createEvent(entity, OPERATION, event, meta, context.store)
 }

--- a/src/mappings/uniques/mint.ts
+++ b/src/mappings/uniques/mint.ts
@@ -10,6 +10,7 @@ import { Action, Context, createTokenId } from '../utils/types'
 import { versionOf, calculateCollectionOwnerCountAndDistribution } from '../utils/helper'
 import { mintHandler } from '../shared/token'
 import { getCreateTokenEvent } from './getters'
+import { markCollectionRarityDirty } from '../utils/rarity'
 
 const OPERATION = Action.MINT
 
@@ -76,6 +77,7 @@ export async function handleTokenCreate(context: Context): Promise<void> {
   success(OPERATION, `${final.id}`)
   await context.store.save(final)
   await context.store.save(collection)
+  markCollectionRarityDirty(collection.id)
   await createEvent(
     final,
     OPERATION,

--- a/src/mappings/uniques/setAttribute.ts
+++ b/src/mappings/uniques/setAttribute.ts
@@ -5,6 +5,7 @@ import { unHex } from '../utils/helper'
 import { Context } from '../utils/types'
 import { getAttributeEvent } from './getters'
 import { attributeFrom, tokenIdOf } from './types'
+import { markCollectionRarityDirty } from '../utils/rarity'
 
 /**
  * Handle the attribute set event (Uniques.AttributeSet, Uniques.AttributeCleared)
@@ -37,4 +38,5 @@ export async function handleAttributeSet(context: Context): Promise<void> {
   }
 
   await context.store.save(final)
+  markCollectionRarityDirty(event.collectionId)
 }

--- a/src/mappings/uniques/setMetadata.ts
+++ b/src/mappings/uniques/setMetadata.ts
@@ -9,6 +9,7 @@ import { updateItemMetadataByCollection } from '../utils/cache'
 import { setMetadataHandler } from '../shared/token'
 import { tokenIdOf } from './types'
 import { getMetadataEvent } from './getters'
+import { markCollectionRarityDirty } from '../utils/rarity'
 
 const OPERATION = 'METADATA' as any
 
@@ -20,6 +21,7 @@ const OPERATION = 'METADATA' as any
 export async function handleMetadataSet(context: Context): Promise<void> {
   const event = unwrap(context, getMetadataEvent)
   debug(OPERATION, event)
+  markCollectionRarityDirty(event.collectionId)
 
   if (!event.metadata) {
     return

--- a/src/mappings/utils/rarity.ts
+++ b/src/mappings/utils/rarity.ts
@@ -1,0 +1,246 @@
+import { emOf } from '@kodadot1/metasquid/entity'
+import { logger } from '@kodadot1/metasquid/logger'
+import { Store } from './types'
+
+const dirtyCollectionIds = new Set<string>()
+
+const RARITY_TIER = {
+  LEGENDARY: 'LEGENDARY',
+  EPIC: 'EPIC',
+  RARE: 'RARE',
+  UNCOMMON: 'UNCOMMON',
+  COMMON: 'COMMON',
+} as const
+
+type RarityTier = typeof RARITY_TIER[keyof typeof RARITY_TIER]
+
+type AttributeRow = {
+  trait?: string | null
+  value?: string | null
+}
+
+type CollectionTokenRow = {
+  id: string
+  sn: string | number | bigint
+  attributes?: AttributeRow[] | null
+}
+
+type RankedToken = {
+  id: string
+  sn: bigint
+  rarityScore: number
+  rarityRank: number | null
+  rarityPercentile: number | null
+  rarityTier: RarityTier
+}
+
+function asSn(sn: string | number | bigint): bigint {
+  if (typeof sn === 'bigint') {
+    return sn
+  }
+
+  if (typeof sn === 'number') {
+    return BigInt(sn)
+  }
+
+  try {
+    return BigInt(sn)
+  } catch {
+    return BigInt(0)
+  }
+}
+
+function attributeKey(attribute: AttributeRow): string | null {
+  const trait = attribute.trait?.trim()
+  const value = attribute.value?.trim()
+
+  if (!trait || !value) {
+    return null
+  }
+
+  return `${trait}::${value}`
+}
+
+export function rarityTierFromPercentile(percentile: number): RarityTier {
+  if (percentile < 1) {
+    return RARITY_TIER.LEGENDARY
+  }
+  if (percentile < 5) {
+    return RARITY_TIER.EPIC
+  }
+  if (percentile < 15) {
+    return RARITY_TIER.RARE
+  }
+  if (percentile < 35) {
+    return RARITY_TIER.UNCOMMON
+  }
+
+  return RARITY_TIER.COMMON
+}
+
+export function calculateCollectionRarity(tokens: CollectionTokenRow[]): RankedToken[] {
+  const total = tokens.length
+  if (!total) {
+    return []
+  }
+
+  const traitCounts = new Map<string, number>()
+  for (const token of tokens) {
+    for (const attribute of token.attributes || []) {
+      const key = attributeKey(attribute)
+      if (!key) {
+        continue
+      }
+      traitCounts.set(key, (traitCounts.get(key) || 0) + 1)
+    }
+  }
+
+  const scored = tokens.map((token) => {
+    const validTraits = (token.attributes || [])
+      .map(attributeKey)
+      .filter((key): key is string => key !== null)
+
+    if (!validTraits.length) {
+      return {
+        id: token.id,
+        sn: asSn(token.sn),
+        rarityScore: 0,
+        hasValidTraits: false,
+      }
+    }
+
+    const rarityScore = validTraits.reduce((score, key) => {
+      const traitCount = traitCounts.get(key)
+      if (!traitCount) {
+        return score
+      }
+
+      return score + total / traitCount
+    }, 0)
+
+    return {
+      id: token.id,
+      sn: asSn(token.sn),
+      rarityScore: Number(rarityScore.toFixed(8)),
+      hasValidTraits: true,
+    }
+  })
+
+  const hasAnyTraitBearingNft = scored.some(token => token.hasValidTraits)
+
+  scored.sort((a, b) => {
+    if (b.rarityScore !== a.rarityScore) {
+      return b.rarityScore - a.rarityScore
+    }
+    if (a.sn !== b.sn) {
+      return a.sn < b.sn ? -1 : 1
+    }
+    return a.id.localeCompare(b.id)
+  })
+
+  if (!hasAnyTraitBearingNft) {
+    return scored.map(token => ({
+      id: token.id,
+      sn: token.sn,
+      rarityScore: 0,
+      rarityRank: null,
+      rarityPercentile: null,
+      rarityTier: RARITY_TIER.COMMON,
+    }))
+  }
+
+  return scored.map((token, index) => {
+    const rarityRank = index + 1
+    const rarityPercentile = Number((((rarityRank - 1) / total) * 100).toFixed(6))
+    const rarityTier = !token.hasValidTraits
+      ? RARITY_TIER.COMMON
+      : rarityTierFromPercentile(rarityPercentile)
+
+    return {
+      id: token.id,
+      sn: token.sn,
+      rarityScore: token.rarityScore,
+      rarityRank,
+      rarityPercentile,
+      rarityTier,
+    }
+  })
+}
+
+export function markCollectionRarityDirty(collectionId: string | null | undefined): void {
+  if (!collectionId) {
+    return
+  }
+
+  dirtyCollectionIds.add(String(collectionId))
+}
+
+async function updateCollectionRarity(store: Store, collectionId: string): Promise<void> {
+  const rows = await emOf(store).query(
+    `
+      SELECT id, sn, attributes
+      FROM nft_entity
+      WHERE collection_id = $1
+        AND burned = false
+    `,
+    [collectionId],
+  ) as CollectionTokenRow[]
+
+  const rankedTokens = calculateCollectionRarity(rows)
+  if (!rankedTokens.length) {
+    return
+  }
+
+  const batchSize = 2000
+  for (let index = 0; index < rankedTokens.length; index += batchSize) {
+    const chunk = rankedTokens.slice(index, index + batchSize)
+
+    const values = chunk
+      .map((_, chunkIndex) => {
+        const base = chunkIndex * 5
+        return `($${base + 1}::text, $${base + 2}::numeric, $${base + 3}::integer, $${base + 4}::numeric, $${base + 5}::text)`
+      })
+      .join(', ')
+
+    const params: Array<string | number | null> = chunk.flatMap(token => [
+      token.id,
+      token.rarityScore,
+      token.rarityRank,
+      token.rarityPercentile,
+      token.rarityTier,
+    ])
+
+    await emOf(store).query(
+      `
+        UPDATE nft_entity AS ne
+        SET rarity_score = v.rarity_score,
+            rarity_rank = v.rarity_rank,
+            rarity_percentile = v.rarity_percentile,
+            rarity_tier = v.rarity_tier
+        FROM (VALUES ${values}) AS v(id, rarity_score, rarity_rank, rarity_percentile, rarity_tier)
+        WHERE ne.id = v.id
+      `,
+      params,
+    )
+  }
+}
+
+export async function flushDirtyCollectionRarity(store: Store): Promise<void> {
+  if (!dirtyCollectionIds.size) {
+    return
+  }
+
+  const collectionIds = Array.from(dirtyCollectionIds)
+  dirtyCollectionIds.clear()
+
+  for (const collectionId of collectionIds) {
+    try {
+      await updateCollectionRarity(store, collectionId)
+    } catch (error) {
+      logger.error(
+        `[RARITY] Failed to update collection ${collectionId}: ${(error as Error).message}`,
+      )
+      throw error
+    }
+  }
+}

--- a/src/model/generated/nftEntity.model.ts
+++ b/src/model/generated/nftEntity.model.ts
@@ -82,6 +82,22 @@ export class NFTEntity {
     sn!: bigint
 
     @Index_()
+    @FloatColumn_({nullable: true})
+    rarityScore!: number | undefined | null
+
+    @Index_()
+    @IntColumn_({nullable: true})
+    rarityRank!: number | undefined | null
+
+    @Index_()
+    @FloatColumn_({nullable: true})
+    rarityPercentile!: number | undefined | null
+
+    @Index_()
+    @StringColumn_({nullable: true})
+    rarityTier!: string | undefined | null
+
+    @Index_()
     @DateTimeColumn_({nullable: false})
     updatedAt!: Date
 

--- a/tests/rarity.test.ts
+++ b/tests/rarity.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { calculateCollectionRarity, rarityTierFromPercentile } from '../src/mappings/utils/rarity'
+
+describe('Rarity', () => {
+  it('calculates score and deterministic ranking', () => {
+    const rows = calculateCollectionRarity([
+      {
+        id: '1-1',
+        sn: 1,
+        attributes: [{ trait: 'color', value: 'red' }],
+      },
+      {
+        id: '1-2',
+        sn: 2,
+        attributes: [{ trait: 'color', value: 'red' }],
+      },
+      {
+        id: '1-3',
+        sn: 3,
+        attributes: [{ trait: 'color', value: 'blue' }],
+      },
+      {
+        id: '1-4',
+        sn: 4,
+        attributes: [],
+      },
+    ])
+
+    expect(rows.map(row => row.id)).toEqual(['1-3', '1-1', '1-2', '1-4'])
+    expect(rows.find(row => row.id === '1-3')?.rarityScore).toBe(4)
+    expect(rows.find(row => row.id === '1-1')?.rarityScore).toBe(2)
+    expect(rows.find(row => row.id === '1-4')?.rarityScore).toBe(0)
+  })
+
+  it('maps percentiles to tiers at exact boundaries', () => {
+    expect(rarityTierFromPercentile(0.9999)).toBe('LEGENDARY')
+    expect(rarityTierFromPercentile(1)).toBe('EPIC')
+    expect(rarityTierFromPercentile(4.9999)).toBe('EPIC')
+    expect(rarityTierFromPercentile(5)).toBe('RARE')
+    expect(rarityTierFromPercentile(14.9999)).toBe('RARE')
+    expect(rarityTierFromPercentile(15)).toBe('UNCOMMON')
+    expect(rarityTierFromPercentile(34.9999)).toBe('UNCOMMON')
+    expect(rarityTierFromPercentile(35)).toBe('COMMON')
+  })
+
+  it('assigns missing traits as common with zero score', () => {
+    const rows = calculateCollectionRarity([
+      { id: '2-1', sn: 1, attributes: [] },
+      { id: '2-2', sn: 2, attributes: [{ trait: 'hat', value: 'cap' }] },
+    ])
+
+    const missing = rows.find(row => row.id === '2-1')
+    expect(missing?.rarityScore).toBe(0)
+    expect(missing?.rarityTier).toBe('COMMON')
+  })
+
+  it('forces common tier when collection has no valid traits', () => {
+    const rows = calculateCollectionRarity([
+      { id: '3-1', sn: 1, attributes: [] },
+      { id: '3-2', sn: 2, attributes: [] },
+      { id: '3-3', sn: 3, attributes: [] },
+    ])
+
+    expect(rows).toHaveLength(3)
+    expect(rows.every(row => row.rarityScore === 0)).toBe(true)
+    expect(rows.every(row => row.rarityTier === 'COMMON')).toBe(true)
+    expect(rows.every(row => row.rarityRank === null)).toBe(true)
+    expect(rows.every(row => row.rarityPercentile === null)).toBe(true)
+  })
+
+  it('keeps traitless NFTs common even when percentile would be uncommon', () => {
+    const rows = calculateCollectionRarity([
+      { id: '4-1', sn: 1, attributes: [{ trait: 'hat', value: 'cap' }] },
+      { id: '4-2', sn: 2, attributes: [] },
+      { id: '4-3', sn: 3, attributes: [] },
+    ])
+
+    const traitless = rows.filter(row => row.rarityScore === 0)
+    expect(traitless).toHaveLength(2)
+    expect(traitless.every(row => row.rarityTier === 'COMMON')).toBe(true)
+  })
+})


### PR DESCRIPTION
- https://github.com/chaotic-art/planning/issues/26

Adds NFT rarity computation and storage to nft entity model

- Added rarityScore, rarityRank, rarityPercentile, and rarityTier to NFTEntity (GraphQL schema, generated model, and DB migration).
- Added indexes for efficient collection-level rarity queries (collection_id + rarity_rank/tier/percentile).
- Implemented collection rarity calculation logic (score, deterministic ranking, percentile, and tier mapping).
- Hooked rarity recalculation into mint/burn/metadata/attribute flows for both nfts and uniques via dirty-collection batching.
- Added tests for ranking determinism, tier boundaries, and traitless NFT edge cases.